### PR TITLE
Activate undesirable_function_linter

### DIFF
--- a/.lintr.R
+++ b/.lintr.R
@@ -35,6 +35,5 @@ linters = all_linters(
   spaces_inside_linter = NULL,
   spaces_left_parentheses_linter = NULL,
   todo_comment_linter = NULL,
-  undesirable_function_linter = NULL,
   unreachable_code_linter = NULL
 )

--- a/.lintr.R
+++ b/.lintr.R
@@ -1,6 +1,14 @@
 linters = all_linters(
   packages = "lintr",
   semicolon_linter(allow_compound = TRUE),
+  # TODO(r-lib/lintr#2172): Finer-tuned handling for some of these.
+  undesirable_function_linter(modify_defaults(
+    defaults = default_undesirable_functions,
+    library = NULL,
+    options = NULL,
+    par = NULL,
+    sapply = NULL
+  )),
   assignment_linter = NULL,
   brace_linter = NULL,
   commas_linter = NULL,
@@ -9,6 +17,7 @@ linters = all_linters(
   cyclocomp_linter = NULL,
   function_argument_linter = NULL,
   function_left_parentheses_linter = NULL,
+  # TODO(r-lib/lintr#2172): Exclude this from vignettes/ enforce elsewhere with allow_scoped=TRUE
   implicit_assignment_linter = NULL,
   # TODO(r-lib/lintr#2172): Exclude this from vignettes/ enforce elsewhere.
   implicit_integer_linter = NULL,
@@ -27,6 +36,5 @@ linters = all_linters(
   spaces_left_parentheses_linter = NULL,
   todo_comment_linter = NULL,
   undesirable_function_linter = NULL,
-  undesirable_operator_linter = NULL,
   unreachable_code_linter = NULL
 )

--- a/R/bit.R
+++ b/R/bit.R
@@ -1206,7 +1206,12 @@ as.which.which <- function(x, maxindex=NA_integer_, ...)x
 #' @describeIn as.which method to coerce to zero length [`which()`][as.which] from
 #'   [`NULL`][NULL]
 #' @export
-as.which.NULL <- function(x, ...)structure(integer(), maxindex=0L, class=c("booltype", "which"))
+as.which.NULL <- function(x, ...) {
+  out = integer()
+  attr(out, "maxindex") = 0L
+  class(out) = c("booltype", "which")
+  out
+}
 
 #' @describeIn as.which method to coerce to [`which()`][as.which] from [numeric()]
 #' @export

--- a/R/rle.R
+++ b/R/rle.R
@@ -140,12 +140,14 @@ rlepack.integer <- function(
       r <- intrle(diff(x))  # returns NULL if rle is inefficient, old condition was 2*length(r$lengths)<n
     else
       r <- NULL
-    structure(list(first=x[1], dat=if (is.null(r)) x else r, last=x[n]), class="rlepack")
+    out = list(first=x[1], dat=if (is.null(r)) x else r, last=x[n])
   }else if (n==1){
-    structure(list(first=x[1], dat=x, last=x[1]), class="rlepack")
+    out = list(first=x[1], dat=x, last=x[1])
   }else{
-    structure(list(first=NA_integer_, dat=x, last=NA_integer_), class="rlepack")
+    out = list(first=NA_integer_, dat=x, last=NA_integer_)
   }
+  class(out) <- "rlepack"
+  out
 }
 
 #' @rdname rlepack

--- a/R/timeutil.R
+++ b/R/timeutil.R
@@ -51,5 +51,7 @@ repeat.time <- function (expr, gcFirst = TRUE, minSec=0.5, envir=parent.frame())
     }
     new.time <- proc.time()
     on.exit()
-    structure((new.time - time0)/r, class = "proc_time")
+    out = (new.time - time0) / r
+    class(out) = "proc_time"
+    out
 }

--- a/tests/testthat/test-bit.R
+++ b/tests/testthat/test-bit.R
@@ -53,6 +53,7 @@ test_that("Can create zero length bitwhich objects", {
   expect_error(as.bitwhich(factor()))
 })
 
+# nolint start: undesirable_function_linter. structure() seems OK here.
 test_that("bitwhich creates correctly", {
   # to check whether we properly obtain integer
   n <- 12
@@ -112,7 +113,7 @@ test_that("bitwhich creates correctly", {
   eval(substitute(expect_identical(bitwhich(0), y), list(y=y)))
   eval(substitute(expect_identical(bitwhich(0, poslength=0), y), list(y=y)))
 })
-
+# nolint end: undesirable_function_linter.
 
 test_that("length<-.bitwhich does set new bits according to the rules given in details", {
   w <- bitwhich(0)

--- a/tests/testthat/test-rle.R
+++ b/tests/testthat/test-rle.R
@@ -48,9 +48,8 @@ test_that("intisdesc is correct", {
 # })
 
 test_that("intrle is correct", {
-  expect_identical(intrle(c(rep(1L,60), 1:30))
-  , structure(list(lengths = c(61L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L), values = 1:30)
-  , .Names = c("lengths", "values"), class = "rle"))
+  x = c(rep(1L, 60), 1:30)
+  expect_identical(intrle(x), rle(x))
   expect_null(intrle(c(rep(1L,60), 1:31)))
 })
 

--- a/vignettes/bit-demo.Rmd
+++ b/vignettes/bit-demo.Rmd
@@ -11,9 +11,9 @@ vignette: >
 
 ```{r, echo = FALSE, results = "hide", message = FALSE}
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
-require(bit)
-.ff.version <- try(packageVersion("ff"), silent = TRUE)
-.ff.is.available <- !inherits(.ff.version, "try-error") && .ff.version >= "4.0.0" && require(ff)
+library(bit)
+.ff.is.available = requireNamespace("ff", quietly=TRUE) && packageVersion("ff") >= "4.0.0"
+if (.ff.is.available) library(ff)
 #tools::buildVignette("vignettes/bit-demo.Rmd")
 #devtools::build_vignettes()
 ```

--- a/vignettes/bit-performance.Rmd
+++ b/vignettes/bit-performance.Rmd
@@ -12,8 +12,8 @@ vignette: >
 
 ```{r, echo = FALSE, results = "hide", message = FALSE}
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
-require(bit)
-require(microbenchmark)
+library(bit)
+library(microbenchmark)
 # rmarkdown::render("vignettes/bit-performance.Rmd")
 # these are the real settings for the performance vignette
 times <- 5

--- a/vignettes/bit-usage.Rmd
+++ b/vignettes/bit-usage.Rmd
@@ -30,9 +30,9 @@ The bit package provides the following S3 functionality:
 
 ```{r, echo = FALSE, results = "hide", message = FALSE}
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
-require(bit)
-.ff.version <- try(packageVersion("ff"), silent = TRUE)
-.ff.is.available <- !inherits(.ff.version, "try-error") && .ff.version >= "4.0.0" && require(ff)
+library(bit)
+.ff.is.available = requireNamespace("ff", quietly=TRUE) && packageVersion("ff") >= "4.0.0"
+if (.ff.is.available) library(ff)
 # rmarkdown::render("vignettes/bit-usage.Rmd")
 # devtools::build_vignettes()
 ```


### PR DESCRIPTION
Also `undesirable_operator_linter()`, for which there are no hits.