### PR TITLE
roxygenize() changes for commas_linter

### DIFF
--- a/man/Extract.Rd
+++ b/man/Extract.Rd
@@ -59,8 +59,8 @@ converted to positive ones, beware the RAM consumption.
   x[] <- c(FALSE, NA, TRUE)
   x[1:2]
   x[-3]
-  x[ri(1,2)]
-  x[as.bitwhich(c(TRUE,TRUE,FALSE))]
+  x[ri(1, 2)]
+  x[as.bitwhich(c(TRUE, TRUE, FALSE))]
   x[[1]]
   x[] <- TRUE
   x[1:2] <- FALSE

--- a/man/Summaries.Rd
+++ b/man/Summaries.Rd
@@ -165,8 +165,8 @@ very skewed.
 
   all(l)
   all(b)
-  all(b, range=c(3,3))
-  all.booltype(l, range=c(3,3))
+  all(b, range=c(3, 3))
+  all.booltype(l, range=c(3, 3))
 
   min(l)
   min(b)

--- a/man/as.bit.Rd
+++ b/man/as.bit.Rd
@@ -79,8 +79,8 @@ to TRUE.  This differs from the NA-to-FALSE coercion in package ff and may
 change in the future.
 }
 \examples{
-as.bit(c(0L,1L,2L,-2L,NA))
-as.bit(c(0,1,2,-2,NA))
+as.bit(c(0L, 1L, 2L, -2L, NA))
+as.bit(c(0, 1, 2, -2, NA))
 
 as.bit(c(FALSE, NA, TRUE))
 

--- a/man/as.bitwhich.Rd
+++ b/man/as.bitwhich.Rd
@@ -74,10 +74,10 @@ else becomes \code{TRUE})
 
 }}
 \examples{
-as.bitwhich(c(0L,1L,2L,-2L,NA))
-as.bitwhich(c(0,1,2,-2,NA))
+as.bitwhich(c(0L, 1L, 2L, -2L, NA))
+as.bitwhich(c(0, 1, 2, -2, NA))
 
- as.bitwhich(c(NA,NA,NA))
+ as.bitwhich(c(NA, NA, NA))
  as.bitwhich(c(FALSE, FALSE, FALSE))
  as.bitwhich(c(FALSE, FALSE, TRUE))
  as.bitwhich(c(FALSE, TRUE, TRUE))

--- a/man/bit_rangediff.Rd
+++ b/man/bit_rangediff.Rd
@@ -27,10 +27,10 @@ of a bit vector; if yes, uses a bit vector for the set operation; if no,
 falls back to a quicksort and \code{\link[=merge_rangediff]{merge_rangediff()}}
 }
 \examples{
-bit_rangediff(c(1L,6L), c(3L,4L))
-bit_rangediff(c(6L,1L), c(3L,4L))
-bit_rangediff(c(6L,1L), c(3L,4L), revx=TRUE)
-bit_rangediff(c(6L,1L), c(3L,4L), revx=TRUE, revy=TRUE)
+bit_rangediff(c(1L, 6L), c(3L, 4L))
+bit_rangediff(c(6L, 1L), c(3L, 4L))
+bit_rangediff(c(6L, 1L), c(3L, 4L), revx=TRUE)
+bit_rangediff(c(6L, 1L), c(3L, 4L), revx=TRUE, revy=TRUE)
 }
 \seealso{
 \code{\link[=bit_setdiff]{bit_setdiff()}}, \code{\link[=merge_rangediff]{merge_rangediff()}}

--- a/man/bit_setops.Rd
+++ b/man/bit_setops.Rd
@@ -36,7 +36,7 @@ for integers.
 determines the range of the integers and checks if the density justifies use
 of a bit vector; if yes, uses a bit vector for finding duplicates; if no,
 falls back to \code{\link[=union]{union()}}, \code{\link[=intersect]{intersect()}},
-\code{\link[=setdiff]{setdiff()}}, \code{union(setdiff(x,y),setdiff(y,x))} and \code{\link[=setequal]{setequal()}}
+\code{\link[=setdiff]{setdiff()}}, \code{union(setdiff(x, y), setdiff(y, x))} and \code{\link[=setequal]{setequal()}}
 }
 \section{Functions}{
 \itemize{

--- a/man/bit_sort.Rd
+++ b/man/bit_sort.Rd
@@ -29,9 +29,9 @@ of a bit vector; if yes, sorts the first occurences of each integer in the
 range using a bit vector, sorts the rest and merges; if no, falls back to quicksort.
 }
 \examples{
-bit_sort(c(2L,1L,NA,NA,1L,2L))
-bit_sort(c(2L,1L,NA,NA,1L,2L), na.last=FALSE)
-bit_sort(c(2L,1L,NA,NA,1L,2L), na.last=TRUE)
+bit_sort(c(2L, 1L, NA, NA, 1L, 2L))
+bit_sort(c(2L, 1L, NA, NA, 1L, 2L), na.last=FALSE)
+bit_sort(c(2L, 1L, NA, NA, 1L, 2L), na.last=TRUE)
 
 \dontrun{
 x <- sample(1e7, replace=TRUE)

--- a/man/bit_sort_unique.Rd
+++ b/man/bit_sort_unique.Rd
@@ -38,12 +38,12 @@ of a bit vector; if yes, creates the result using a bit vector; if no, falls bac
 \code{sort(unique())}
 }
 \examples{
-bit_sort_unique(c(2L,1L,NA,NA,1L,2L))
-bit_sort_unique(c(2L,1L,NA,NA,1L,2L), na.last=FALSE)
-bit_sort_unique(c(2L,1L,NA,NA,1L,2L), na.last=TRUE)
-bit_sort_unique(c(2L,1L,NA,NA,1L,2L), decreasing = TRUE)
-bit_sort_unique(c(2L,1L,NA,NA,1L,2L), decreasing = TRUE, na.last=FALSE)
-bit_sort_unique(c(2L,1L,NA,NA,1L,2L), decreasing = TRUE, na.last=TRUE)
+bit_sort_unique(c(2L, 1L, NA, NA, 1L, 2L))
+bit_sort_unique(c(2L, 1L, NA, NA, 1L, 2L), na.last=FALSE)
+bit_sort_unique(c(2L, 1L, NA, NA, 1L, 2L), na.last=TRUE)
+bit_sort_unique(c(2L, 1L, NA, NA, 1L, 2L), decreasing = TRUE)
+bit_sort_unique(c(2L, 1L, NA, NA, 1L, 2L), decreasing = TRUE, na.last=FALSE)
+bit_sort_unique(c(2L, 1L, NA, NA, 1L, 2L), decreasing = TRUE, na.last=TRUE)
 
 \dontrun{
 x <- sample(1e7, replace=TRUE)

--- a/man/bit_unidup.Rd
+++ b/man/bit_unidup.Rd
@@ -58,21 +58,21 @@ falls back to \code{\link[=unique]{unique()}}, \code{\link[=duplicated]{duplicat
 
 }}
 \examples{
-bit_unique(c(2L,1L,NA,NA,1L,2L))
-bit_unique(c(2L,1L,NA,NA,1L,2L), na.rm=FALSE)
-bit_unique(c(2L,1L,NA,NA,1L,2L), na.rm=TRUE)
+bit_unique(c(2L, 1L, NA, NA, 1L, 2L))
+bit_unique(c(2L, 1L, NA, NA, 1L, 2L), na.rm=FALSE)
+bit_unique(c(2L, 1L, NA, NA, 1L, 2L), na.rm=TRUE)
 
-bit_duplicated(c(2L,1L,NA,NA,1L,2L))
-bit_duplicated(c(2L,1L,NA,NA,1L,2L), na.rm=FALSE)
-bit_duplicated(c(2L,1L,NA,NA,1L,2L), na.rm=TRUE)
+bit_duplicated(c(2L, 1L, NA, NA, 1L, 2L))
+bit_duplicated(c(2L, 1L, NA, NA, 1L, 2L), na.rm=FALSE)
+bit_duplicated(c(2L, 1L, NA, NA, 1L, 2L), na.rm=TRUE)
 
-bit_anyDuplicated(c(2L,1L,NA,NA,1L,2L))
-bit_anyDuplicated(c(2L,1L,NA,NA,1L,2L), na.rm=FALSE)
-bit_anyDuplicated(c(2L,1L,NA,NA,1L,2L), na.rm=TRUE)
+bit_anyDuplicated(c(2L, 1L, NA, NA, 1L, 2L))
+bit_anyDuplicated(c(2L, 1L, NA, NA, 1L, 2L), na.rm=FALSE)
+bit_anyDuplicated(c(2L, 1L, NA, NA, 1L, 2L), na.rm=TRUE)
 
-bit_sumDuplicated(c(2L,1L,NA,NA,1L,2L))
-bit_sumDuplicated(c(2L,1L,NA,NA,1L,2L), na.rm=FALSE)
-bit_sumDuplicated(c(2L,1L,NA,NA,1L,2L), na.rm=TRUE)
+bit_sumDuplicated(c(2L, 1L, NA, NA, 1L, 2L))
+bit_sumDuplicated(c(2L, 1L, NA, NA, 1L, 2L), na.rm=FALSE)
+bit_sumDuplicated(c(2L, 1L, NA, NA, 1L, 2L), na.rm=TRUE)
 }
 \seealso{
 \code{\link[=bit_sort_unique]{bit_sort_unique()}}

--- a/man/bitsort.Rd
+++ b/man/bitsort.Rd
@@ -24,7 +24,7 @@ In one pass over the vector \code{NA}s are handled according to parameter
 bit sort is invoked.
 }
 \examples{
-bitsort(c(2L,0L,1L,NA,2L))
-bitsort(c(2L,0L,1L,NA,2L), na.last=TRUE)
-bitsort(c(2L,0L,1L,NA,2L), na.last=FALSE)
+bitsort(c(2L, 0L, 1L, NA, 2L))
+bitsort(c(2L, 0L, 1L, NA, 2L), na.last=TRUE)
+bitsort(c(2L, 0L, 1L, NA, 2L), na.last=FALSE)
 }

--- a/man/bitwhich_representation.Rd
+++ b/man/bitwhich_representation.Rd
@@ -17,8 +17,8 @@ Diagnose representation of bitwhich
 }
 \examples{
 bitwhich_representation(bitwhich())
-bitwhich_representation(bitwhich(12,FALSE))
-bitwhich_representation(bitwhich(12,TRUE))
+bitwhich_representation(bitwhich(12, FALSE))
+bitwhich_representation(bitwhich(12, TRUE))
 bitwhich_representation(bitwhich(12, -3))
 bitwhich_representation(bitwhich(12, 3))
 }

--- a/man/c.booltype.Rd
+++ b/man/c.booltype.Rd
@@ -25,7 +25,7 @@ Creating new boolean vectors by concatenating boolean vectors
  c(bit(4), !bit(4))
  c(bit(4), !bitwhich(4))
  c(bitwhich(4), !bit(4))
- c(ri(1,2,4), !bit(4))
+ c(ri(1, 2, 4), !bit(4))
  c(bit(4), !logical(4))
  message("logical in first argument does not dispatch: c(logical(4), bit(4))")
  c.booltype(logical(4), !bit(4))

--- a/man/chunk.Rd
+++ b/man/chunk.Rd
@@ -48,11 +48,11 @@ for example \code{\link[ff:chunk.ffdf]{ff::chunk.ffdf()}}
   chunk(raw(1e7))
   chunk(raw(1e7), length=3)
 
-  chunks(1,10,3)
+  chunks(1, 10, 3)
   # no longer do
-  chunk(1,100,10)
+  chunk(1, 100, 10)
   # but for bckward compatibility this works
-  chunk(from=1,to=100,by=10)
+  chunk(from=1, to=100, by=10)
 
 }
 \seealso{

--- a/man/clone.Rd
+++ b/man/clone.Rd
@@ -36,12 +36,12 @@ point to the same memory.
 
   x <- 1:12
   y <- x
-  still.identical(x,y)
+  still.identical(x, y)
   y[1] <- y[1]
-  still.identical(x,y)
+  still.identical(x, y)
   y <- clone(x)
-  still.identical(x,y)
-  rm(x,y); gc()
+  still.identical(x, y)
+  rm(x, y); gc()
 
 }
 \seealso{

--- a/man/copy_vector.Rd
+++ b/man/copy_vector.Rd
@@ -25,8 +25,8 @@ This can be substantially faster than \code{duplicate(as.vector(unclass(x)))}
 x <- factor(letters)
 y <- x
 z <- copy_vector(x)
-still.identical(x,y)
-still.identical(x,z)
+still.identical(x, y)
+still.identical(x, z)
 str(x)
 str(y)
 str(z)

--- a/man/countsort.Rd
+++ b/man/countsort.Rd
@@ -21,7 +21,7 @@ In one pass over the vector \code{NA}s are handled according to parameter
 counting sort is invoked.
 }
 \examples{
-countsort(c(2L,0L,1L,NA,2L))
-countsort(c(2L,0L,1L,NA,2L), na.last=TRUE)
-countsort(c(2L,0L,1L,NA,2L), na.last=FALSE)
+countsort(c(2L, 0L, 1L, NA, 2L))
+countsort(c(2L, 0L, 1L, NA, 2L), na.last=TRUE)
+countsort(c(2L, 0L, 1L, NA, 2L), na.last=FALSE)
 }

--- a/man/firstNA.Rd
+++ b/man/firstNA.Rd
@@ -16,7 +16,7 @@ a reversed vector
 This is substantially faster than \code{which.max(is.na(x))}
 }
 \examples{
-x <- c(FALSE,NA,TRUE)
+x <- c(FALSE, NA, TRUE)
 firstNA(x)
 reverse_vector(x)
 \dontrun{

--- a/man/getsetattr.Rd
+++ b/man/getsetattr.Rd
@@ -103,7 +103,7 @@ delete the non-names attributes like \code{\link[=attributes]{attributes()}} doe
 
   system.time(x <- mysimplefactor(1e7))
   memory.size(max=TRUE)
-  system.time(setattr(x, "levels", c("a","b")))
+  system.time(setattr(x, "levels", c("a", "b")))
   memory.size(max=TRUE)
   x[1:4]
   memory.size(max=TRUE)
@@ -112,7 +112,7 @@ delete the non-names attributes like \code{\link[=attributes]{attributes()}} doe
 
   system.time(x <- simplefactor(1e7))
   memory.size(max=TRUE)
-  system.time(levels(x) <- c("x","y"))
+  system.time(levels(x) <- c("x", "y"))
   memory.size(max=TRUE)
   x[1:4]
   memory.size(max=TRUE)

--- a/man/in.bitwhich.Rd
+++ b/man/in.bitwhich.Rd
@@ -23,7 +23,7 @@ If the table is sorted, this can be much faster than \code{\link[=match]{\%in\%}
 \examples{
 x <- bitwhich(100)
 x[3] <- TRUE
-in.bitwhich(c(NA,2,3), x)
+in.bitwhich(c(NA, 2, 3), x)
 }
 \seealso{
 \code{\link[=match]{\%in\%}}

--- a/man/intrle.Rd
+++ b/man/intrle.Rd
@@ -15,7 +15,7 @@ intisdesc(x, na.method = c("none", "break", "skip")[1])
 \arguments{
 \item{x}{an integer vector}
 
-\item{na.method}{one of "none","break","skip", see details. The strange defaults stem
+\item{na.method}{one of "none", "break", "skip", see details. The strange defaults stem
 from the initial usage.}
 }
 \value{

--- a/man/maxindex.Rd
+++ b/man/maxindex.Rd
@@ -91,14 +91,14 @@ The generic \code{poslength} gives the number of positively selected elements, i
 
 }}
 \examples{
-r <- ri(1,2,12)
+r <- ri(1, 2, 12)
 i <- as.which(r)
 w <- as.bitwhich(r)
 b <- as.bit(r)
 l <- as.logical(r)
 u <- which(l)      # unclassed which
 
-sapply(list(r=r,u=u,i=i,w=w,b=b,l=l), function(x){
+sapply(list(r=r, u=u, i=i, w=w, b=b, l=l), function(x){
   c(length=length(x), sum=sum(x), maxindex=maxindex(x), poslength=poslength(x))
 })
 }

--- a/man/merge_rev.Rd
+++ b/man/merge_rev.Rd
@@ -193,17 +193,17 @@ x is empty), hence \code{x[n]} or \code{merge_rev(x)[n]}
 
 \item \code{merge_firstin()}: quickly returns the first common element of a range rx and a
 sorted set y, (or \code{NA} if the intersection is empty), hence
-\code{merge_first(merge_rangesect(rx,y))}
+\code{merge_first(merge_rangesect(rx, y))}
 
 \item \code{merge_lastin()}: quickly returns the last common element of a range rx and a
 sorted set y, (or \code{NA} if the intersection is empty), hence
-\code{merge_last(merge_rangesect(rx,y))}
+\code{merge_last(merge_rangesect(rx, y))}
 
 \item \code{merge_firstnotin()}: quickly returns the first element of a range rx which is not in a
-sorted set y (or \code{NA} if all rx are in y), hence \code{merge_first(merge_rangediff(rx,y))}
+sorted set y (or \code{NA} if all rx are in y), hence \code{merge_first(merge_rangediff(rx, y))}
 
 \item \code{merge_lastnotin()}: quickly returns the last element of a range rx which is not in a
-sorted set y (or \code{NA} if all rx are in y), hence \code{merge_last(merge_rangediff(rx,y))}
+sorted set y (or \code{NA} if all rx are in y), hence \code{merge_last(merge_rangediff(rx, y))}
 
 }}
 \note{
@@ -222,28 +222,28 @@ merge_match(merge_rev(1:7), merge_rev(3:9))
 merge_in(1:7, 3:9)
 merge_notin(1:7, 3:9)
 
-merge_anyDuplicated(c(1L,1L,2L,3L))
-merge_duplicated(c(1L,1L,2L,3L))
-merge_unique(c(1L,1L,2L,3L))
+merge_anyDuplicated(c(1L, 1L, 2L, 3L))
+merge_duplicated(c(1L, 1L, 2L, 3L))
+merge_unique(c(1L, 1L, 2L, 3L))
 
-merge_union(c(1L,2L,2L,2L), c(2L,2L,3L))
-merge_union(c(1L,2L,2L,2L), c(2L,2L,3L), method="exact")
-merge_union(c(1L,2L,2L,2L), c(2L,2L,3L), method="all")
+merge_union(c(1L, 2L, 2L, 2L), c(2L, 2L, 3L))
+merge_union(c(1L, 2L, 2L, 2L), c(2L, 2L, 3L), method="exact")
+merge_union(c(1L, 2L, 2L, 2L), c(2L, 2L, 3L), method="all")
 
-merge_setdiff(c(1L,2L,2L,2L), c(2L,2L,3L))
-merge_setdiff(c(1L,2L,2L,2L), c(2L,2L,3L), method="exact")
-merge_setdiff(c(1L,2L,2L), c(2L,2L,2L,3L), method="exact")
+merge_setdiff(c(1L, 2L, 2L, 2L), c(2L, 2L, 3L))
+merge_setdiff(c(1L, 2L, 2L, 2L), c(2L, 2L, 3L), method="exact")
+merge_setdiff(c(1L, 2L, 2L), c(2L, 2L, 2L, 3L), method="exact")
 
-merge_symdiff(c(1L,2L,2L,2L), c(2L,2L,3L))
-merge_symdiff(c(1L,2L,2L,2L), c(2L,2L,3L), method="exact")
-merge_symdiff(c(1L,2L,2L), c(2L,2L,2L,3L), method="exact")
+merge_symdiff(c(1L, 2L, 2L, 2L), c(2L, 2L, 3L))
+merge_symdiff(c(1L, 2L, 2L, 2L), c(2L, 2L, 3L), method="exact")
+merge_symdiff(c(1L, 2L, 2L), c(2L, 2L, 2L, 3L), method="exact")
 
-merge_intersect(c(1L,2L,2L,2L), c(2L,2L,3L))
-merge_intersect(c(1L,2L,2L,2L), c(2L,2L,3L), method="exact")
+merge_intersect(c(1L, 2L, 2L, 2L), c(2L, 2L, 3L))
+merge_intersect(c(1L, 2L, 2L, 2L), c(2L, 2L, 3L), method="exact")
 
-merge_setequal(c(1L,2L,2L), c(1L,2L))
-merge_setequal(c(1L,2L,2L), c(1L,2L,2L))
-merge_setequal(c(1L,2L,2L), c(1L,2L), method="exact")
-merge_setequal(c(1L,2L,2L), c(1L,2L,2L), method="exact")
+merge_setequal(c(1L, 2L, 2L), c(1L, 2L))
+merge_setequal(c(1L, 2L, 2L), c(1L, 2L, 2L))
+merge_setequal(c(1L, 2L, 2L), c(1L, 2L), method="exact")
+merge_setequal(c(1L, 2L, 2L), c(1L, 2L, 2L), method="exact")
 
 }

--- a/man/quicksort2.Rd
+++ b/man/quicksort2.Rd
@@ -21,7 +21,7 @@ In one pass over the vector \code{NA}s are handled according to parameter
 binary quicksort is invoked.
 }
 \examples{
-quicksort2(c(2L,0L,1L,NA,2L))
-quicksort2(c(2L,0L,1L,NA,2L), na.last=TRUE)
-quicksort2(c(2L,0L,1L,NA,2L), na.last=FALSE)
+quicksort2(c(2L, 0L, 1L, NA, 2L))
+quicksort2(c(2L, 0L, 1L, NA, 2L), na.last=TRUE)
+quicksort2(c(2L, 0L, 1L, NA, 2L), na.last=FALSE)
 }

--- a/man/quicksort3.Rd
+++ b/man/quicksort3.Rd
@@ -21,7 +21,7 @@ In one pass over the vector \code{NA}s are handled according to parameter
 threeway quicksort is invoked.
 }
 \examples{
-countsort(c(2L,0L,1L,NA,2L))
-countsort(c(2L,0L,1L,NA,2L), na.last=TRUE)
-countsort(c(2L,0L,1L,NA,2L), na.last=FALSE)
+countsort(c(2L, 0L, 1L, NA, 2L))
+countsort(c(2L, 0L, 1L, NA, 2L), na.last=TRUE)
+countsort(c(2L, 0L, 1L, NA, 2L), na.last=FALSE)
 }

--- a/man/range_na.Rd
+++ b/man/range_na.Rd
@@ -21,7 +21,7 @@ an integer vector with three elements:
 Get range and number of NAs
 }
 \examples{
-range_na(c(0L,1L,2L,NA))
+range_na(c(0L, 1L, 2L, NA))
 }
 \seealso{
 \code{\link[=range_nanozero]{range_nanozero()}} and \code{\link[=range_sortna]{range_sortna()}}

--- a/man/range_nanozero.Rd
+++ b/man/range_nanozero.Rd
@@ -22,7 +22,7 @@ elements:
 Remove zeros and get range and number of NAs
 }
 \examples{
-range_nanozero(c(0L,1L,2L,NA))
+range_nanozero(c(0L, 1L, 2L, NA))
 }
 \seealso{
 \code{\link[=range_na]{range_na()}} and \code{\link[=range_sortna]{range_sortna()}}

--- a/man/range_sortna.Rd
+++ b/man/range_sortna.Rd
@@ -30,12 +30,12 @@ In one pass over the vector \code{NA}s are treated according to parameter
 number of \code{NA}s and unsortedness is determined.
 }
 \examples{
-range_sortna(c(0L,1L,NA,2L))
-range_sortna(c(2L,NA,1L,0L))
-range_sortna(c(0L,1L,NA,2L), na.last=TRUE)
-range_sortna(c(2L,NA,1L,0L), na.last=TRUE)
-range_sortna(c(0L,1L,NA,2L), na.last=FALSE)
-range_sortna(c(2L,NA,1L,0L), na.last=FALSE)
+range_sortna(c(0L, 1L, NA, 2L))
+range_sortna(c(2L, NA, 1L, 0L))
+range_sortna(c(0L, 1L, NA, 2L), na.last=TRUE)
+range_sortna(c(2L, NA, 1L, 0L), na.last=TRUE)
+range_sortna(c(0L, 1L, NA, 2L), na.last=FALSE)
+range_sortna(c(2L, NA, 1L, 0L), na.last=FALSE)
 }
 \seealso{
 \code{\link[=range_na]{range_na()}} and \code{\link[=range_nanozero]{range_nanozero()}}

--- a/man/rep.booltype.Rd
+++ b/man/rep.booltype.Rd
@@ -27,10 +27,10 @@ Creating new bit or bitwhich by recycling such vectors
 }
 \examples{
 
- rep(as.bit(c(FALSE,TRUE)), 2)
- rep(as.bit(c(FALSE,TRUE)), length.out=7)
- rep(as.bitwhich(c(FALSE,TRUE)), 2)
- rep(as.bitwhich(c(FALSE,TRUE)), length.out=1)
+ rep(as.bit(c(FALSE, TRUE)), 2)
+ rep(as.bit(c(FALSE, TRUE)), length.out=7)
+ rep(as.bitwhich(c(FALSE, TRUE)), 2)
+ rep(as.bitwhich(c(FALSE, TRUE)), length.out=1)
 }
 \seealso{
 \code{\link[=rep]{rep()}}, \code{\link[=bit]{bit()}} , \code{\link[=bitwhich]{bitwhich()}}

--- a/man/rev.booltype.Rd
+++ b/man/rev.booltype.Rd
@@ -21,8 +21,8 @@ Creating new bit or bitwhich by reversing such vectors
 }
 \examples{
 
- rev(as.bit(c(FALSE,TRUE)))
- rev(as.bitwhich(c(FALSE,TRUE)))
+ rev(as.bit(c(FALSE, TRUE)))
+ rev(as.bitwhich(c(FALSE, TRUE)))
 }
 \seealso{
 \code{\link[=rev]{rev()}}, \code{\link[=bit]{bit()}} , \code{\link[=bitwhich]{bitwhich()}}

--- a/man/ri.Rd
+++ b/man/ri.Rd
@@ -30,7 +30,7 @@ of the data
 }
 \examples{
 
- bit(12)[ri(1,6)]
+ bit(12)[ri(1, 6)]
 
 }
 \seealso{

--- a/man/still.identical.Rd
+++ b/man/still.identical.Rd
@@ -21,6 +21,6 @@ Test for C-level identity of two atomic vectors
 x <- 1:2
 y <- x
 z <- copy_vector(x)
-still.identical(y,x)
-still.identical(z,x)
+still.identical(y, x)
+still.identical(z, x)
 }

--- a/man/symdiff.Rd
+++ b/man/symdiff.Rd
@@ -12,18 +12,18 @@ symdiff(x, y)
 \item{y}{a vector}
 }
 \value{
-\code{union(setdiff(x,y), setdiff(y,x))}
+\code{union(setdiff(x, y), setdiff(y, x))}
 }
 \description{
 Symmetric set complement
 }
 \note{
-that \code{symdiff(x,y)} is not \code{\link[=identical]{identical()}}
-as \code{symdiff(y,x)} without applying \code{\link[=sort]{sort()}} to the result
+that \code{symdiff(x, y)} is not \code{\link[=identical]{identical()}}
+as \code{symdiff(y, x)} without applying \code{\link[=sort]{sort()}} to the result
 }
 \examples{
-symdiff(c(1L,2L,2L), c(2L,3L))
-symdiff(c(2L,3L), c(1L,2L,2L))
+symdiff(c(1L, 2L, 2L), c(2L, 3L))
+symdiff(c(2L, 3L), c(1L, 2L, 2L))
 }
 \seealso{
 \code{\link[=merge_symdiff]{merge_symdiff()}} and \code{\link[=xor]{xor()}}

--- a/man/vecseq.Rd
+++ b/man/vecseq.Rd
@@ -37,13 +37,13 @@ return a call instead of the evaluated sequence.
 }
 \examples{
 
-  sequence(c(3,4))
-  vecseq(c(3,4))
-  vecseq(c(1,11), c(5, 15))
-  vecseq(c(1,11), c(5, 15), concat=FALSE, eval=FALSE)
-  vecseq(c(1,11), c(5, 15), concat=FALSE, eval=TRUE)
-  vecseq(c(1,11), c(5, 15), concat=TRUE, eval=FALSE)
-  vecseq(c(1,11), c(5, 15), concat=TRUE, eval=TRUE)
+  sequence(c(3, 4))
+  vecseq(c(3, 4))
+  vecseq(c(1, 11), c(5, 15))
+  vecseq(c(1, 11), c(5, 15), concat=FALSE, eval=FALSE)
+  vecseq(c(1, 11), c(5, 15), concat=FALSE, eval=TRUE)
+  vecseq(c(1, 11), c(5, 15), concat=TRUE, eval=FALSE)
+  vecseq(c(1, 11), c(5, 15), concat=TRUE, eval=TRUE)
 
 }
 \seealso{

--- a/man/xor.Rd
+++ b/man/xor.Rd
@@ -147,7 +147,7 @@ much faster than the multiple calls in \code{(x | y) & !(x & y)}
   x|as.bit(y)
   x|as.bitwhich(y)
   x|as.which(y)
-  x|ri(1,1,9)
+  x|ri(1, 1, 9)
 
 
 }


### PR DESCRIPTION
Follow-up to #26, which failed to cascade changes to `#'` comments into corresponding Rd files