### PR TITLE
Don't start lines with '{'

### DIFF
--- a/R/attrutil.R
+++ b/R/attrutil.R
@@ -120,8 +120,7 @@
 #'
 #'
 #' @export
-getsetattr <- function(x, which, value)
-{
+getsetattr <- function(x, which, value) {
   ret <- copy_vector(attr(x, which))
   .Call(C_R_bit_set_attr, x, which, value)
   ret
@@ -129,23 +128,20 @@ getsetattr <- function(x, which, value)
 
 #' @rdname getsetattr
 #' @export
-setattr <- function(x, which, value)
-{
+setattr <- function(x, which, value) {
   .Call(C_R_bit_set_attr, x, which, value)
   invisible()
 }
 
 #' @rdname getsetattr
 #' @export
-setattributes <- function(x, attributes)
-{
+setattributes <- function(x, attributes) {
   nam <- names(attributes)
   for (i in seq_len(length(attributes))){
     .Call(C_R_bit_set_attr, x, nam[[i]], attributes[[i]])
   }
   invisible()
 }
-
 
 #' Attribute removal
 #'

--- a/R/bit.R
+++ b/R/bit.R
@@ -340,8 +340,6 @@ bitwhich <- function(
   ret
 }
 
-
-
 #' Diagnose representation of bitwhich
 #'
 #' @param x a [bitwhich()] object
@@ -353,12 +351,7 @@ bitwhich <- function(
 #' bitwhich_representation(bitwhich(12, -3))
 #' bitwhich_representation(bitwhich(12, 3))
 #' @export
-bitwhich_representation <- function(x)
-{
-  .Call(C_R_bitwhich_representation, x)
-}
-
-
+bitwhich_representation <- function(x) .Call(C_R_bitwhich_representation, x)
 
 #' Print method for bitwhich
 #'

--- a/R/chunkutil.R
+++ b/R/chunkutil.R
@@ -287,18 +287,16 @@ if (FALSE){
 #'    }
 #'
 #' @export
-
 chunks <- function(
-  from = NULL
-  , to = NULL
-  , by = NULL
-  , length.out = NULL
-  , along.with = NULL
-  , overlap = 0L
-  , method=c("bbatch", "seq")
-  , maxindex = NA
-)
-{
+  from = NULL,
+  to = NULL,
+  by = NULL,
+  length.out = NULL,
+  along.with = NULL,
+  overlap = 0L,
+  method=c("bbatch", "seq"),
+  maxindex = NA
+) {
   method <- match.arg(method)
   if (!is.null(along.with)){
     if (is.null(from))

--- a/tests/testthat/test-old-regtest.R
+++ b/tests/testthat/test-old-regtest.R
@@ -1,7 +1,5 @@
-regtest.bit <- function(
-  N = 50  # number of repetitions for random regression tests
-)
-{
+#' @param N number of repetitions for random regression tests
+regtest.bit <- function(N = 50) {
   OK <- TRUE
   pool <- c(FALSE, TRUE)
 


### PR DESCRIPTION
Related: #27. After this, two more rules affecting code preventing `brace_linter()` activation.